### PR TITLE
Switch to our fork of netlink library

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/twistlock/go-nfqueue/internal/unix"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 func extractAttribute(log *log.Logger, a *Attribute, data []byte) error {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/twistlock/go-nfqueue
 go 1.12
 
 require (
-	github.com/mdlayher/netlink v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/twistlock/netlink v1.1.1-0.20200412211849-6260ab5842f9 // indirect
 	golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775
 )

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,10 @@ github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4 h1:nwOc1YaOrY
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/mdlayher/netlink v0.0.0-20190409211403-11939a169225/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
 github.com/mdlayher/netlink v1.0.0/go.mod h1:KxeJAFOFLG6AjpyDkQ/iIhxygIUKD+vcwqcnu43w/+M=
-github.com/mdlayher/netlink v1.1.0 h1:mpdLgm+brq10nI9zM1BpX1kpDbh3NLl3RSnVq6ZSkfg=
-github.com/mdlayher/netlink v1.1.0/go.mod h1:H4WCitaheIsdF9yOYu8CFmCgQthAPIWZmcKp9uZHgmY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/twistlock/netlink v1.1.1-0.20200412211849-6260ab5842f9 h1:xTLCa8Vawca0z4FAcirfOv7zVuZwMOoLxG7IdVSre8s=
+github.com/twistlock/netlink v1.1.1-0.20200412211849-6260ab5842f9/go.mod h1:xI4H2K+O7esTMMn9mWmbZBc4KVzGAynS935i96wTBWc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -23,6 +23,7 @@ golang.org/x/sys v0.0.0-20190411185658-b44545bcd369/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775 h1:TC0v2RSO1u2kn1ZugjrFXkRZAEaqMN/RW+OTZkBzmLE=
 golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/nfqueue.go
+++ b/nfqueue.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/twistlock/go-nfqueue/internal/unix"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 	"github.com/pkg/errors"
 )
 

--- a/nfqueue_gteq_1.12.go
+++ b/nfqueue_gteq_1.12.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/twistlock/go-nfqueue/internal/unix"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 // Nfqueue represents a netfilter queue handler
@@ -38,7 +38,8 @@ func Open(config *Config) (*Nfqueue, error) {
 		return nil, ErrInvFlag
 	}
 
-	con, err := netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: config.NetNS})
+	// Disable netlink goroutine spawned in a different namespce, if no explicit network namespace is specified in the config
+	con, err := netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: config.NetNS, DisableNSGoroutine: config.NetNS == 0})
 	if err != nil {
 		return nil, err
 	}

--- a/nfqueue_lt_1.12.go
+++ b/nfqueue_lt_1.12.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/twistlock/go-nfqueue/internal/unix"
 
-	"github.com/mdlayher/netlink"
+	"github.com/twistlock/netlink"
 )
 
 type verdict struct {
@@ -43,7 +43,8 @@ func Open(config *Config) (*Nfqueue, error) {
 		return nil, ErrInvFlag
 	}
 
-	con, err := netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: config.NetNS})
+	// Disable netlink goroutine spawned in a different namespce, if no explicit network namespace is specified in the config
+	con, err := netlink.Dial(unix.NETLINK_NETFILTER, &netlink.Config{NetNS: config.NetNS, DisableNSGoroutine: config.NetNS == 0})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Switch to using our forked netlink library and use the new toggle to disable NS goroutine
when no explicit namespace was provided.